### PR TITLE
feat: add ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize, reopened]
+jobs:
+  project-build-test:
+    uses: asimov-protocol/.github/.github/workflows/npm-ci.yml@v1.0
+    with:
+      skip-tests: true


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow configuration for continuous integration (CI) to the repository. The workflow is triggered on pushes and pull requests to the `main` branch.

### CI Workflow Configuration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R13): Introduced a new CI workflow named `CI`, which uses a reusable workflow from `asimov-protocol/.github/.github/workflows/npm-ci.yml@v1.0` for building and testing the project. The workflow skips tests by default, as specified in the `with` configuration. It is triggered on `push` and `pull_request` events for the `main` branch.
