### PR TITLE
fix: base path for deploy

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 import path from 'path';
 
 export default defineConfig({
+	base: '/',
 	plugins: [
 		tailwindcss(),
 		sveltekit(),


### PR DESCRIPTION
This pull request introduces a small change to the `vite.config.ts` file by adding a `base` property with the value `'/'` to the configuration. This sets the base path for the application when served in production.
