### PR TITLE
chore: hide some modules

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -3,7 +3,12 @@ import { load as yamlLoad } from 'js-yaml';
 
 const GITHUB_API_BASE = 'https://api.github.com';
 const ORG_NAME = 'asimov-modules';
-const EXCLUDED_REPOS = ['.github'];
+const EXCLUDED_REPOS = [
+	'.github',
+	'asimov-modules.rb',
+	'asimov-modules.py',
+	'asimov-goodreads-module'
+];
 
 export class GitHubAPI {
 	private token?: string;


### PR DESCRIPTION
This pull request updates the list of excluded repositories in the `GitHubAPI` class to include additional module repositories. This ensures that these repositories are ignored when performing operations that involve the organization.

Key change:

* [`src/lib/github.ts`](diffhunk://#diff-1694b20d1194df7e39a31c079e2ecf60319839b84d39cba2a5b2e765321960b8L6-R6): Expanded the `EXCLUDED_REPOS` array to include `'asimov-modules.rb'`, `'asimov-modules.py'`, and `'asimov-goodreads-module'`.