### PR TITLE
fix: link to module on sources page

### DIFF
--- a/src/components/SourceCard.svelte
+++ b/src/components/SourceCard.svelte
@@ -226,6 +226,7 @@
 									class="bg-oOrange-50 text-oOrange-700 border-oOrange-200 hover:bg-oOrange-100 hover:border-oOrange-300 flex items-center space-x-1 rounded-full border px-2 py-1 text-xs transition-colors"
 									title="Flows: {source.flows.join(', ') || 'None specified'}"
 									target="_blank"
+									rel="noopener noreferrer"
 								>
 									<Package size={12} />
 									<span>{source.module_label}</span>

--- a/src/components/SourceCard.svelte
+++ b/src/components/SourceCard.svelte
@@ -222,9 +222,10 @@
 							<span class="text-gGray-500 text-xs">Modules:</span>
 							{#each endpointSources as source (source.module_name)}
 								<a
-									href="/modules/{source.module_name}"
+									href="https://github.com/asimov-modules/{source.module_name}"
 									class="bg-oOrange-50 text-oOrange-700 border-oOrange-200 hover:bg-oOrange-100 hover:border-oOrange-300 flex items-center space-x-1 rounded-full border px-2 py-1 text-xs transition-colors"
 									title="Flows: {source.flows.join(', ') || 'None specified'}"
+									target="_blank"
 								>
 									<Package size={12} />
 									<span>{source.module_label}</span>


### PR DESCRIPTION
This pull request updates the `SourceCard.svelte` component to enhance the user experience by modifying module links to point to external GitHub repositories and ensuring they open in a new tab.

Changes to `SourceCard.svelte`:

* Updated the `href` attribute for module links to point to the corresponding GitHub repository (`https://github.com/asimov-modules/{source.module_name}`) instead of a relative path.
* Added the `target="_blank"` attribute to ensure module links open in a new browser tab.