### PR TITLE
feat: display modules only

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -207,7 +207,9 @@ export class GitHubAPI {
 			}
 
 			const repos = await response.json();
-			const filteredRepos = repos.filter(this.shouldIncludeRepo);
+			const filteredRepos = repos.filter(
+				(repo: any) => this.shouldIncludeRepo(repo) && repo.name.toLowerCase().includes('module')
+			);
 
 			const modulesWithContributors = await Promise.all(
 				filteredRepos.map(async (repo: any) => {


### PR DESCRIPTION
This pull request includes a refinement to the `GitHubAPI` class in `src/lib/github.ts`. The change updates the repository filtering logic to include only repositories whose names contain the word "module" (case-insensitive) in addition to meeting the existing `shouldIncludeRepo` criteria.

* [`src/lib/github.ts`](diffhunk://#diff-1694b20d1194df7e39a31c079e2ecf60319839b84d39cba2a5b2e765321960b8L210-R212): Modified the `filteredRepos` logic to filter repositories by both the `shouldIncludeRepo` method and a name check for "module" (case-insensitive).
