### PR TITLE
fix: better source names

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,7 +5,7 @@ import {
   FacebookLogo,
   InstagramLogo,
   LinkedinLogo,
-  TwitterLogo,
+  XLogo,
   YoutubeLogo,
   GoogleLogo,
   Briefcase,
@@ -21,8 +21,8 @@ export const DOMAIN_ICONS: Record<string, React.ComponentType<any>> = {
   'facebook.com': FacebookLogo,
   'instagram.com': InstagramLogo,
   'linkedin.com': LinkedinLogo,
-  'twitter.com': TwitterLogo,
-  'x.com': TwitterLogo,
+  'twitter.com': XLogo,
+  'x.com': XLogo,
   'youtube.com': YoutubeLogo,
   'google.com': GoogleLogo,
   'indeed.com': Briefcase,
@@ -32,12 +32,30 @@ export const DOMAIN_ICONS: Record<string, React.ComponentType<any>> = {
   'yahoo.com': ChartLineUp
 };
 
+const DOMAIN_NAMES: Record<string, string> = {
+  'twitter.com': 'X (Twitter)',
+  'x.com': 'X (Twitter)',
+  'ebay.com': 'eBay',
+  'linkedin.com': 'LinkedIn',
+  '*.linkedin.com': 'LinkedIn',
+  'duckduckgo.com': 'DuckDuckGo',
+  'youtube.com': 'YouTube',
+};
+
 export function getDomainIcon(domain: string): React.ComponentType<any> {
   const IconComponent = DOMAIN_ICONS[domain.toLowerCase()] || Globe;
   return IconComponent;
 }
 
 export function generateDisplayName(domain: string): string {
+  const lowerDomain = domain.toLowerCase();
+
+  // Check if we have a custom name for this domain
+  if (DOMAIN_NAMES[lowerDomain]) {
+    return DOMAIN_NAMES[lowerDomain];
+  }
+
+  // Default logic: capitalize each part separated by hyphens
   const domainName = domain.split('.')[0];
   return domainName
     .split('-')


### PR DESCRIPTION
This pull request updates how social media domains are represented and displayed in the app, with a particular focus on the rebranding of Twitter to X. It also introduces a mapping for custom display names for several domains to improve user-facing text.

**Domain icon and display name updates:**

* Replaced all references to `TwitterLogo` with `XLogo` for both `twitter.com` and `x.com` in the `DOMAIN_ICONS` mapping, reflecting Twitter's rebranding to X. [[1]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L8-R8) [[2]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L24-R25)
* Added a new `DOMAIN_NAMES` mapping for custom display names, including "X (Twitter)" for both `twitter.com` and `x.com`, as well as improved names for other domains like eBay, LinkedIn, DuckDuckGo, and YouTube.
* Updated the `generateDisplayName` function to use the new `DOMAIN_NAMES` mapping when available, falling back to the default logic if not.