### PR TITLE
fix: analytics

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -33,6 +33,8 @@ const { title = 'ASIMOV.Directory', description = 'ASIMOV Data Sources Directory
 
     <ClientRouter />
     <slot name="head" />
+
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="fdbc7ec3-ff92-4e77-948a-2cdeeeb4f630"></script>
   </head>
   <body>
     <slot />


### PR DESCRIPTION
After refactoring to astro analytics script has been deleted. This pull request adds a single change to the `src/layouts/Layout.astro` file to enable website analytics tracking.

* Added the Umami analytics script to the `<head>` section to enable visitor tracking.