### PR TITLE
chore: remove title and description from pages

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,14 +35,6 @@ const canonicalUrl = 'https://asimov.directory/';
 
   <div class="bg-gGray-100 min-h-screen">
     <div class="container mx-auto px-4 py-8">
-      <div class="mb-8">
-        <h1 class="text-sSlate-800 mb-4 text-4xl font-bold">ASIMOV Data Sources</h1>
-        <p class="text-gGray-500 max-w-2xl text-lg">
-          Discover and explore available data sources from the ASIMOV ecosystem. Find endpoints,
-          formats, and modules for seamless data integration.
-        </p>
-      </div>
-
       <SourcesApp client:load />
     </div>
   </div>

--- a/src/pages/modules.astro
+++ b/src/pages/modules.astro
@@ -40,13 +40,6 @@ const canonicalUrl = 'https://asimov.directory/modules';
 
   <div class="bg-gGray-100 min-h-screen" id="modules-page">
     <div class="container mx-auto px-4 py-8">
-      <div class="mb-8">
-        <h1 class="text-sSlate-800 mb-4 text-4xl font-bold">ASIMOV Modules</h1>
-        <p class="text-gGray-500 max-w-2xl text-lg">
-          Discover and explore our collection of modules from the ASIMOV ecosystem
-        </p>
-      </div>
-
       <ModulesApp client:load initialSort={initialSort} />
     </div>
   </div>


### PR DESCRIPTION
This pull request removes the introductory header and description sections from both the data sources and modules landing pages. The main application components (`SourcesApp` and `ModulesApp`) now appear at the top of their respective pages without a title or descriptive text.

**Page layout simplification:**

* Removed the header (`h1`) and introductory paragraph from the top of the `src/pages/index.astro` data sources page.
* Removed the header (`h1`) and introductory paragraph from the top of the `src/pages/modules.astro` modules page.